### PR TITLE
Adapt Stream<> API to be compatibile to OpenSSL

### DIFF
--- a/src/lib/asio/asio_async_handshake_op.h
+++ b/src/lib/asio/asio_async_handshake_op.h
@@ -10,7 +10,7 @@ namespace Botan {
 template <class Channel, class StreamLayer, class Handler>
 struct AsyncHandshakeOperation
    {
-      AsyncHandshakeOperation(Channel& channel, StreamCore& core,
+      AsyncHandshakeOperation(Channel* channel, StreamCore& core,
                               StreamLayer& nextLayer, Handler&& handler)
          : channel_(channel),
            core_(core),
@@ -36,7 +36,7 @@ struct AsyncHandshakeOperation
                boost::asio::buffer(core_.input_buffer_, bytesTransferred);
             try
                {
-               channel_.received_data(
+               channel_->received_data(
                   static_cast<const uint8_t*>(read_buffer.data()),
                   read_buffer.size());
                }
@@ -58,7 +58,7 @@ struct AsyncHandshakeOperation
             return;
             }
 
-         if(!channel_.is_active() && !ec)
+         if(!channel_->is_active() && !ec)
             {
             // we need more tls data from the socket
             nextLayer_.async_read_some(core_.input_buffer_, std::move(*this));
@@ -76,7 +76,7 @@ struct AsyncHandshakeOperation
          }
 
    private:
-      Channel& channel_;
+      Channel* channel_;
       StreamCore& core_;
       StreamLayer& nextLayer_;
       Handler handler_;

--- a/src/lib/asio/asio_async_read_op.h
+++ b/src/lib/asio/asio_async_read_op.h
@@ -11,7 +11,7 @@ template <class Channel, class StreamLayer, class Handler,
           class MutableBufferSequence>
 struct AsyncReadOperation
    {
-      AsyncReadOperation(Channel& channel, StreamCore& core, StreamLayer& nextLayer,
+      AsyncReadOperation(Channel* channel, StreamCore& core, StreamLayer& nextLayer,
                          Handler&& handler, const MutableBufferSequence& buffers)
          : channel_(channel), core_(core), nextLayer_(nextLayer),
            handler_(std::forward<Handler>(handler)), buffers_(buffers) {}
@@ -35,8 +35,8 @@ struct AsyncReadOperation
                boost::asio::buffer(core_.input_buffer_, bytes_transferred);
             try
                {
-               channel_.received_data(static_cast<const uint8_t*>(read_buffer.data()),
-                                      read_buffer.size());
+               channel_->received_data(static_cast<const uint8_t*>(read_buffer.data()),
+                                       read_buffer.size());
                }
             catch(...)
                {
@@ -63,7 +63,7 @@ struct AsyncReadOperation
          }
 
    private:
-      Channel& channel_;
+      Channel* channel_;
       StreamCore& core_;
       StreamLayer& nextLayer_;
       Handler handler_;

--- a/src/lib/asio/asio_stream.h
+++ b/src/lib/asio/asio_stream.h
@@ -59,6 +59,12 @@ class Stream : public StreamBase<Channel>
          : StreamBase<Channel>(std::forward<Args>(args)...),
            nextLayer_(std::forward<StreamLayer>(nextLayer)) {}
 
+      Stream(Stream &&other) = default;
+      Stream& operator=(Stream &&other) = default;
+
+      Stream(const Stream &other) = delete;
+      Stream& operator=(const Stream &other) = delete;
+
       //
       // -- -- accessor methods
       //

--- a/src/tests/unit_asio_stream.cpp
+++ b/src/tests/unit_asio_stream.cpp
@@ -169,10 +169,10 @@ class ASIO_Stream_Tests final : public Test
          MockSocket socket;
          TestStream ssl{socket};
 
-         ssl.handshake();
+         ssl.handshake(TestStream::client);
 
          Test::Result result("sync TLS handshake");
-         result.test_eq("feeds data into channel until active", ssl.channel().is_active(), true);
+         result.test_eq("feeds data into channel until active", ssl.native_handle()->is_active(), true);
          results.push_back(result);
          }
 
@@ -185,10 +185,10 @@ class ASIO_Stream_Tests final : public Test
          socket.ec_             = expected_ec;
 
          error_code ec;
-         ssl.handshake(ec);
+         ssl.handshake(TestStream::client, ec);
 
          Test::Result result("sync TLS handshake error");
-         result.test_eq("does not activate channel", ssl.channel().is_active(), false);
+         result.test_eq("does not activate channel", ssl.native_handle()->is_active(), false);
          result.confirm("propagates error code", ec == expected_ec);
          results.push_back(result);
          }
@@ -202,10 +202,10 @@ class ASIO_Stream_Tests final : public Test
 
          auto handler = [&](const boost::system::error_code&)
             {
-            result.test_eq("feeds data into channel until active", ssl.channel().is_active(), true);
+            result.test_eq("feeds data into channel until active", ssl.native_handle()->is_active(), true);
             };
 
-         ssl.async_handshake(handler);
+         ssl.async_handshake(TestStream::client, handler);
          results.push_back(result);
          }
 
@@ -221,11 +221,11 @@ class ASIO_Stream_Tests final : public Test
 
          auto handler = [&](const boost::system::error_code &ec)
             {
-            result.test_eq("does not activate channel", ssl.channel().is_active(), false);
+            result.test_eq("does not activate channel", ssl.native_handle()->is_active(), false);
             result.confirm("propagates error code", ec == expected_ec);
             };
 
-         ssl.async_handshake(handler);
+         ssl.async_handshake(TestStream::client, handler);
          results.push_back(result);
          }
 
@@ -465,6 +465,7 @@ class ASIO_Stream_Tests final : public Test
          results.push_back(result);
          }
 
+
    public:
       std::vector<Test::Result> run() override
          {
@@ -498,6 +499,6 @@ class ASIO_Stream_Tests final : public Test
 
 BOTAN_REGISTER_TEST("asio_stream", ASIO_Stream_Tests);
 
-#endif
-
 }  // namespace Botan_Tests
+
+#endif


### PR DESCRIPTION
# API Adaptions

## Missing Typedefs

* `handshake_type` -- enum with either `client` or `server`
* `native_handle_type` -- a pointer to the underlying native handle (a subclass of `Botan::TLS::Channel` in our case)

## Missing Methods

* `const lowest_layer_type& lowest_layer() const` -- simple const overload
* `void handshake(handshake_type, const ConstBufferSequence&)` -- buffered synchronous handshake, I guess we want to implement that?
* `void handshake(handshake_type, const ConstBufferSequence&, boost::system::error_code&)` -- non-throwing overload, see above
* `DERIVED async_handshake(handshake_type, const ConstBufferSequence &, BufferedHandshakeHandler&&)` -- async overload, see above
* `void async_shutdown(ShutdownHandler&&)` -- async shutdown operation, probably we can implement that?
* `void set_verify_callback(VerifyCallback)` -- probably not needed for now
* `void set_verify_callback(VerifyCallback, boost::system::error_code&)` -- probably not needed for now
* `void set_verify_depth(int)` -- probably not needed
* `void set_verify_depth(int, boost::system::error_code&)` -- probably not needed
* `set_verify_mode(verify_mode)` -- probably not needed
* `set_verify_mode(verify_mode, boost::system::error_code&)` -- probably not needed

## Adapted Method Signatures

* `DERIVED async_handshake(handshake_type, HandshakeHandler&&)` -- throws if `type != client`
* `void handshake(handshake_type, boost::system::error_code&)` -- sets `ec` if `type != client`
* `void handshake(handshake_type)` -- throws if `type != client`
* `native_handle_type native_handle()` -- returns a pointer to `Channel` (replacement for `channel()`)

# Considerations regarding ssl::context Compatibility

One thing that we might want to have a look at, is to build a compatibility class for [`ssl::context`](https://www.boost.org/doc/libs/1_69_0/doc/html/boost_asio/reference/ssl__context.html). It seems that the closest artefact in Botan would be the `Credentials_Manager`, probably a simple mapping isn't too hard. Things that are not easily mappable could also be marked with `Not_Implemented()` exceptions...