### PR TITLE
Improve async operations

### DIFF
--- a/src/lib/tls/asio/asio_async_base.h
+++ b/src/lib/tls/asio/asio_async_base.h
@@ -9,8 +9,6 @@
 #ifndef BOTAN_ASIO_ASYNC_BASE_H_
 #define BOTAN_ASIO_ASYNC_BASE_H_
 
-#include <boost/beast/core/bind_handler.hpp>
-
 #include <boost/asio/coroutine.hpp>
 #include <botan/internal/asio_includes.h>
 

--- a/src/lib/tls/asio/asio_async_base.h
+++ b/src/lib/tls/asio/asio_async_base.h
@@ -1,0 +1,68 @@
+/*
+* TLS ASIO Stream Helper
+* (C) 2018-2019 Jack Lloyd
+*     2018-2019 Hannes Rantzsch, Tim Oesterreich, Rene Meusel
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_ASIO_ASYNC_BASE_H_
+#define BOTAN_ASIO_ASYNC_BASE_H_
+
+#include <boost/beast/core/bind_handler.hpp>
+
+#include <botan/internal/asio_includes.h>
+
+namespace Botan {
+
+namespace TLS {
+
+template <class Handler, class Executor, class Allocator>
+struct AsyncBase
+   {
+      using allocator_type = boost::asio::associated_allocator_t<Handler, Allocator>;
+      using executor_type = boost::asio::associated_executor_t<Handler, Executor>;
+
+      allocator_type get_allocator() const noexcept
+         {
+         return boost::asio::get_associated_allocator(m_handler);
+         }
+
+      executor_type get_executor() const noexcept
+         {
+         return boost::asio::get_associated_executor(m_handler, m_work.get_executor());
+         }
+
+   protected:
+      template <class HandlerT>
+      AsyncBase(HandlerT&& handler, const Executor& executor)
+         : m_handler(std::forward<HandlerT>(handler))
+         , m_work(executor)
+         {
+         }
+
+      template<class... Args>
+      void invoke(bool isContinuation, Args&& ... args)
+         {
+         if(!isContinuation)
+            {
+            boost::asio::post(boost::asio::bind_executor(
+                                 m_work.get_executor(), boost::beast::bind_handler(std::move(m_handler), args...))
+                             );
+
+            m_work.reset();
+            }
+         else
+            {
+            m_handler(std::forward<Args>(args)...);
+            m_work.reset();
+            }
+         }
+
+      Handler m_handler;
+      boost::asio::executor_work_guard<executor_type> m_work;
+   };
+}
+}
+
+#endif

--- a/src/lib/tls/asio/asio_async_base.h
+++ b/src/lib/tls/asio/asio_async_base.h
@@ -46,6 +46,7 @@ struct AsyncBase
          {
          if(!isContinuation)
             {
+            // \note(toesterreich): Is this ok to do with bind_handler? Do we need placeholders?
             boost::asio::post(boost::asio::bind_executor(
                                  m_work.get_executor(), boost::beast::bind_handler(std::move(m_handler), args...))
                              );

--- a/src/lib/tls/asio/asio_async_handshake_op.h
+++ b/src/lib/tls/asio/asio_async_handshake_op.h
@@ -60,11 +60,10 @@ struct AsyncHandshakeOperation : public AsyncBase<Handler, typename Stream::exec
          // send tls packets
          if(m_core.hasDataToSend())
             {
-            // TODO comment: plainBytesTransferred is 0 here because...  we construct a write operation to use it only
-            // as a handler for our async_write call, not for actually calling it.  However, once
-            // AsyncWriteOperation::operator() is called as the handler, it will consume the send buffer and call (this)
-            // as it's own handler. Now we know that AsyncHandshakeOperation::operator() checks bytesTransferred first.
-            // We want it to NOT receive data into the channel, hence we set plainBytesTransferred to 0 here.
+            // \note: we construct `AsyncWriteOperation` with 0 as its last parameter (`plainBytesTransferred`).
+            //        This operation will eventually call `*this` as its own handler, passing the 0 back to this call
+            //        operator. This is necessary because, the check of `bytesTransferred > 0` assumes that
+            //        `bytesTransferred` bytes were just read and are in the cores input_buffer for further processing.
             AsyncWriteOperation<
             AsyncHandshakeOperation<typename std::decay<Handler>::type, Stream, Allocator>,
                                     Stream,

--- a/src/lib/tls/asio/asio_async_handshake_op.h
+++ b/src/lib/tls/asio/asio_async_handshake_op.h
@@ -11,8 +11,10 @@
 
 #include <botan/internal/asio_async_write_op.h>
 #include <botan/internal/asio_convert_exceptions.h>
-#include <botan/internal/asio_stream_core.h>
 #include <botan/internal/asio_includes.h>
+#include <botan/internal/asio_stream_core.h>
+
+#include <boost/asio/yield.hpp>
 
 namespace Botan {
 
@@ -41,55 +43,70 @@ struct AsyncHandshakeOperation : public AsyncBase<Handler, typename Stream::exec
 
       void operator()(boost::system::error_code ec, std::size_t bytesTransferred, bool isContinuation = true)
          {
-         // process tls packets from socket first
-         if(bytesTransferred > 0)
+         m_ec = ec;
+         reenter(this)
             {
-            boost::asio::const_buffer read_buffer {m_core.input_buffer.data(), bytesTransferred};
-            try
+            // process tls packets from socket first
+
+            if(bytesTransferred > 0)
                {
-               m_stream.native_handle()->received_data(static_cast<const uint8_t*>(read_buffer.data()), read_buffer.size());
+               boost::asio::const_buffer read_buffer {m_core.input_buffer.data(), bytesTransferred};
+               try
+                  {
+                  m_stream.native_handle()->received_data(static_cast<const uint8_t*>(read_buffer.data()), read_buffer.size());
+                  }
+               catch(const std::exception&)
+                  {
+                  m_ec = convertException();
+                  }
                }
-            catch(const std::exception&)
+
+            // send tls packets
+            if(m_core.hasDataToSend() && !m_ec)
                {
-               ec = convertException();
-               this->invoke(isContinuation, ec);
+               // \note: we construct `AsyncWriteOperation` with 0 as its last parameter (`plainBytesTransferred`).
+               //        This operation will eventually call `*this` as its own handler, passing the 0 back to this call
+               //        operator. This is necessary because, the check of `bytesTransferred > 0` assumes that
+               //        `bytesTransferred` bytes were just read and are in the cores input_buffer for further processing.
+               AsyncWriteOperation<
+               AsyncHandshakeOperation<typename std::decay<Handler>::type, Stream, Allocator>,
+                                       Stream,
+                                       Allocator>
+                                       op{std::move(*this), m_stream, m_core, 0};
+               boost::asio::async_write(m_stream.next_layer(), m_core.sendBuffer(), std::move(op));
                return;
                }
-            }
 
-         // send tls packets
-         if(m_core.hasDataToSend())
-            {
-            // \note: we construct `AsyncWriteOperation` with 0 as its last parameter (`plainBytesTransferred`).
-            //        This operation will eventually call `*this` as its own handler, passing the 0 back to this call
-            //        operator. This is necessary because, the check of `bytesTransferred > 0` assumes that
-            //        `bytesTransferred` bytes were just read and are in the cores input_buffer for further processing.
-            AsyncWriteOperation<
-            AsyncHandshakeOperation<typename std::decay<Handler>::type, Stream, Allocator>,
-                                    Stream,
-                                    Allocator>
-                                    op{std::move(*this), m_stream, m_core, 0};
-            boost::asio::async_write(m_stream.next_layer(), m_core.sendBuffer(), std::move(op));
-            return;
-            }
+            // we need more tls data from the socket
+            if(!m_stream.native_handle()->is_active() && !m_ec)
+               {
+               m_stream.next_layer().async_read_some(m_core.input_buffer, std::move(*this));
+               return;
+               }
 
-         // we need more tls data from the socket
-         if(!m_stream.native_handle()->is_active() && !ec)
-            {
-            m_stream.next_layer().async_read_some(m_core.input_buffer, std::move(*this));
-            return;
-            }
+            if(!isContinuation)
+               {
+               // this 0 byte read completes immediately. `yield` causes the coroutine to reenter the function after
+               // this read, enabling us to call the handler, while respecting asios guarantee that the handler will not
+               // be called without an intermediate initiating function
+               yield m_stream.next_layer().async_read_some(boost::asio::mutable_buffer(), std::move(*this));
+               }
 
-         this->invoke(isContinuation, ec);
+            this->invoke_now(m_ec);
+            }
          }
 
    private:
-      Stream&      m_stream;
-      StreamCore&  m_core;
+      Stream&     m_stream;
+      StreamCore& m_core;
+
+      boost::system::error_code m_ec;
    };
 
 }  // namespace TLS
 
 }  // namespace Botan
+
+#include <boost/asio/unyield.hpp>
 
 #endif

--- a/src/lib/tls/asio/asio_async_read_op.h
+++ b/src/lib/tls/asio/asio_async_read_op.h
@@ -9,6 +9,7 @@
 #ifndef BOTAN_ASIO_ASYNC_READ_OP_H_
 #define BOTAN_ASIO_ASYNC_READ_OP_H_
 
+#include <botan/internal/asio_async_base.h>
 #include <botan/internal/asio_convert_exceptions.h>
 #include <botan/internal/asio_includes.h>
 #include <botan/internal/asio_stream_core.h>
@@ -17,34 +18,39 @@ namespace Botan {
 
 namespace TLS {
 
-template <class Handler, class StreamLayer, class Channel, class MutableBufferSequence>
-struct AsyncReadOperation
+template <class Handler, class Stream, class MutableBufferSequence, class Allocator = std::allocator<void>>
+struct AsyncReadOperation : public AsyncBase<Handler, typename Stream::executor_type, Allocator>
    {
       template <class HandlerT>
       AsyncReadOperation(HandlerT&& handler,
-                         StreamLayer& nextLayer,
-                         Channel* channel,
+                         Stream& stream,
                          StreamCore& core,
                          const MutableBufferSequence& buffers)
-         : m_handler(std::forward<HandlerT>(handler))
-         , m_nextLayer(nextLayer)
-         , m_channel(channel)
+         : AsyncBase<Handler, typename Stream::executor_type, Allocator>(
+              std::forward<HandlerT>(handler),
+              stream.get_executor())
+         , m_stream(stream)
          , m_core(core)
-         , m_buffers(buffers) {}
+         , m_buffers(buffers)
+         {
+         }
 
       AsyncReadOperation(AsyncReadOperation&&) = default;
 
-      void operator()(boost::system::error_code ec, std::size_t bytes_transferred)
+      using typename AsyncBase<Handler, typename Stream::executor_type, Allocator>::allocator_type;
+      using typename AsyncBase<Handler, typename Stream::executor_type, Allocator>::executor_type;
+
+      void operator()(boost::system::error_code ec, std::size_t bytes_transferred, bool isContinuation = true)
          {
          std::size_t decodedBytes = 0;
 
          if(bytes_transferred > 0 && !ec)
             {
-            boost::asio::const_buffer read_buffer {m_core.input_buffer.data(), bytes_transferred};
+            boost::asio::const_buffer read_buffer{m_core.input_buffer.data(), bytes_transferred};
             try
                {
-               m_channel->received_data(static_cast<const uint8_t*>(read_buffer.data()),
-                                        read_buffer.size());
+               m_stream.native_handle()->received_data(static_cast<const uint8_t*>(read_buffer.data()),
+                                                       read_buffer.size());
                }
             catch(const std::exception&)
                {
@@ -55,23 +61,21 @@ struct AsyncReadOperation
          if(!m_core.hasReceivedData() && !ec)
             {
             // we need more tls packets from the socket
-            m_nextLayer.async_read_some(m_core.input_buffer, std::move(*this));
+            m_stream.next_layer().async_read_some(m_core.input_buffer, std::move(*this));
             return;
             }
 
          if(m_core.hasReceivedData() && !ec)
             {
             decodedBytes = m_core.copyReceivedData(m_buffers);
-            ec = boost::system::error_code{};
+            ec = {};
             }
 
-         m_handler(ec, decodedBytes);
+         this->invoke(isContinuation, ec, decodedBytes);
          }
 
    private:
-      Handler               m_handler;
-      StreamLayer&          m_nextLayer;
-      Channel*              m_channel;
+      Stream&               m_stream;
       StreamCore&           m_core;
       MutableBufferSequence m_buffers;
    };

--- a/src/lib/tls/asio/asio_async_write_op.h
+++ b/src/lib/tls/asio/asio_async_write_op.h
@@ -43,19 +43,20 @@ struct AsyncWriteOperation : public AsyncBase<Handler, typename Stream::executor
 
    void operator()(boost::system::error_code ec, std::size_t bytes_transferred, bool isContinuation = true)
       {
-      m_ec = ec;
       reenter(this)
          {
          m_core.consumeSendBuffer(bytes_transferred);
 
          if(!isContinuation)
             {
+            m_ec_store = ec;
             yield m_stream.next_layer().async_write_some(boost::asio::const_buffer(), std::move(*this));
+            ec = m_ec_store;
             }
 
          // the size of the sent TLS record can differ from the size of the payload due to TLS encryption. We need to tell
          // the handler how many bytes of the original data we already processed.
-         this->invoke_now(m_ec, m_ec ? 0 : m_plainBytesTransferred);
+         this->invoke_now(ec, ec ? 0 : m_plainBytesTransferred);
          }
       }
 
@@ -63,7 +64,7 @@ struct AsyncWriteOperation : public AsyncBase<Handler, typename Stream::executor
    StreamCore& m_core;
    std::size_t m_plainBytesTransferred;
 
-   boost::system::error_code m_ec;
+   boost::system::error_code m_ec_store;
    };
 
 }  // namespace TLS

--- a/src/lib/tls/asio/asio_async_write_op.h
+++ b/src/lib/tls/asio/asio_async_write_op.h
@@ -42,6 +42,8 @@ struct AsyncWriteOperation : public AsyncBase<Handler, typename Stream::executor
    void operator()(boost::system::error_code ec, std::size_t bytes_transferred, bool isContinuation = true)
       {
       m_core.consumeSendBuffer(bytes_transferred);
+      // the size of the sent TLS record can differ from the size of the payload due to TLS encryption. We need to tell
+      // the handler how many bytes of the original data we already processed.
       this->invoke(isContinuation, ec, ec ? 0 : m_plainBytesTransferred);
       }
 

--- a/src/lib/tls/asio/asio_error.h
+++ b/src/lib/tls/asio/asio_error.h
@@ -44,12 +44,9 @@ enum class error
    unknown
    };
 
-using error_code = boost::system::error_code;
-using error_category = boost::system::error_category;
-
 namespace detail {
 // TLS Alerts
-struct BotanAlertCategory : error_category
+struct BotanAlertCategory : boost::system::error_category
    {
    const char* name() const noexcept override
       {
@@ -69,7 +66,7 @@ inline const BotanAlertCategory& botan_alert_category() noexcept
    return category;
    }
 
-struct BotanErrorCategory : error_category
+struct BotanErrorCategory : boost::system::error_category
    {
    const char* name() const noexcept override
       {
@@ -138,14 +135,14 @@ inline const BotanErrorCategory& botan_category() noexcept
    }
 } // namespace detail
 
-inline error_code make_error_code(Botan::TLS::Alert::Type c)
+inline boost::system::error_code make_error_code(Botan::TLS::Alert::Type c)
    {
-   return error_code(static_cast<int>(c), detail::botan_alert_category());
+   return boost::system::error_code(static_cast<int>(c), detail::botan_alert_category());
    }
 
-inline error_code make_error_code(error c)
+inline boost::system::error_code make_error_code(error c)
    {
-   return error_code(static_cast<int>(c), detail::botan_category());
+   return boost::system::error_code(static_cast<int>(c), detail::botan_category());
    }
 
 }  // namespace TLS

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -191,10 +191,9 @@ class Stream final : public StreamBase<Channel>
 
          boost::asio::async_completion<HandshakeHandler, void(boost::system::error_code)> init(handler);
 
-         AsyncHandshakeOperation<typename std::decay<HandshakeHandler>::type, StreamLayer, Channel>
-         op{std::move(init.completion_handler), m_nextLayer, native_handle(), this->m_core};
-
-         op(boost::system::error_code{}, 0, 1);
+         AsyncHandshakeOperation<typename std::decay<HandshakeHandler>::type, Stream>
+         op{std::move(init.completion_handler), *this, this->m_core};
+         op({}, 0, false);
 
          return init.result.get();
          }
@@ -407,8 +406,9 @@ class Stream final : public StreamBase<Channel>
             return init.result.get();
             }
 
-         Botan::TLS::AsyncWriteOperation<typename std::decay<WriteHandler>::type>
+         Botan::TLS::AsyncWriteOperation<typename std::decay<WriteHandler>::type, Stream>
          op{std::move(init.completion_handler),
+            *this,
             this->m_core,
             sent};
          boost::asio::async_write(m_nextLayer, this->m_core.sendBuffer(), std::move(op));
@@ -425,13 +425,12 @@ class Stream final : public StreamBase<Channel>
 
          boost::asio::async_completion<ReadHandler, void(boost::system::error_code, std::size_t)> init(handler);
 
-         AsyncReadOperation<typename std::decay<ReadHandler>::type, StreamLayer, Channel, MutableBufferSequence>
+         AsyncReadOperation<typename std::decay<ReadHandler>::type, Stream, MutableBufferSequence>
          op{std::move(init.completion_handler),
-            m_nextLayer,
-            native_handle(),
+            *this,
             this->m_core,
             buffers};
-         op(boost::system::error_code{}, 0);
+         op({}, 0, false);
 
          return init.result.get();
          }

--- a/src/lib/tls/asio/info.txt
+++ b/src/lib/tls/asio/info.txt
@@ -8,6 +8,7 @@ asio_error.h
 </header:public>
 
 <header:internal>
+asio_async_base.h
 asio_async_handshake_op.h
 asio_async_read_op.h
 asio_async_write_op.h


### PR DESCRIPTION
This aims to improve the async operations according to review comments on https://github.com/randombit/botan/pull/1839. 
All async operations now inherit `asio_async_base`, which implements the `allocator` and `executor` hooks. It also handles calling the handler via `boost::asio::post` if it was to be called directly from the calling thread without intermediate initiating functions.