### PR TITLE
Fix: do not call handler from init function

### DIFF
--- a/src/lib/tls/asio/asio_async_base.h
+++ b/src/lib/tls/asio/asio_async_base.h
@@ -46,7 +46,7 @@ struct AsyncBase : boost::asio::coroutine
          }
 
       template<class... Args>
-      void invoke_now(Args&& ... args)
+      void complete_now(Args&& ... args)
          {
          m_handler(std::forward<Args>(args)...);
          m_work_guard_1.reset();

--- a/src/lib/tls/asio/asio_async_write_op.h
+++ b/src/lib/tls/asio/asio_async_write_op.h
@@ -51,10 +51,11 @@ struct AsyncWriteOperation : public AsyncBase<Handler, typename Stream::executor
          {
          m_core.consumeSendBuffer(bytes_transferred);
 
-         if(m_core.hasDataToSend() && !ec){
-            boost::asio::async_write(m_stream.next_layer(), m_core.sendBuffer(), std::move(*this));
+         if(m_core.hasDataToSend() && !ec)
+            {
+            m_stream.next_layer().async_write_some(m_core.sendBuffer(), std::move(*this));
             return;
-         }
+            }
 
          if(!isContinuation)
             {
@@ -65,7 +66,7 @@ struct AsyncWriteOperation : public AsyncBase<Handler, typename Stream::executor
 
          // the size of the sent TLS record can differ from the size of the payload due to TLS encryption. We need to tell
          // the handler how many bytes of the original data we already processed.
-         this->complete_now(ec, ec ? 0 : m_plainBytesTransferred);
+         this->complete_now(ec, m_plainBytesTransferred);
          }
       }
 

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -379,6 +379,8 @@ class Stream : public StreamBase<Channel>
             }
          catch(const std::exception&)
             {
+            // we can't be sure how many bytes were commited here, so clear the send_buffer and try again
+            this->m_core.clearSendBuffer();
             Botan::TLS::AsyncWriteOperation<typename std::decay<WriteHandler>::type, Stream>
             op{std::move(init.completion_handler),
                *this,

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -198,7 +198,7 @@ class Stream : public StreamBase<Channel>
 
          AsyncHandshakeOperation<typename std::decay<HandshakeHandler>::type, Stream>
          op{std::move(init.completion_handler), *this, this->m_core};
-         op({}, 0, false);
+         op({}, std::size_t(0), false);
 
          return init.result.get();
          }
@@ -380,7 +380,7 @@ class Stream : public StreamBase<Channel>
             }
          catch(const std::exception&)
             {
-            init.completion_handler(Botan::TLS::convertException(), 0);
+            init.completion_handler(Botan::TLS::convertException(), std::size_t(0));
             return init.result.get();
             }
 
@@ -408,7 +408,7 @@ class Stream : public StreamBase<Channel>
             *this,
             this->m_core,
             buffers};
-         op({}, 0, false);
+         op({}, std::size_t(0), false);
 
          return init.result.get();
          }

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -198,7 +198,6 @@ class Stream : public StreamBase<Channel>
 
          AsyncHandshakeOperation<typename std::decay<HandshakeHandler>::type, Stream>
          op{std::move(init.completion_handler), *this, this->m_core};
-         op({}, std::size_t(0), false);
 
          return init.result.get();
          }
@@ -386,7 +385,6 @@ class Stream : public StreamBase<Channel>
                this->m_core,
                std::size_t(0),
                Botan::TLS::convertException()};
-            boost::asio::async_write(m_nextLayer, this->m_core.sendBuffer(), std::move(op));
             return init.result.get();
             }
 
@@ -395,7 +393,6 @@ class Stream : public StreamBase<Channel>
             *this,
             this->m_core,
             sent};
-         boost::asio::async_write(m_nextLayer, this->m_core.sendBuffer(), std::move(op));
 
          return init.result.get();
          }
@@ -414,7 +411,6 @@ class Stream : public StreamBase<Channel>
             *this,
             this->m_core,
             buffers};
-         op({}, std::size_t(0), false);
 
          return init.result.get();
          }

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -380,7 +380,13 @@ class Stream : public StreamBase<Channel>
             }
          catch(const std::exception&)
             {
-            init.completion_handler(Botan::TLS::convertException(), std::size_t(0));
+            Botan::TLS::AsyncWriteOperation<typename std::decay<WriteHandler>::type, Stream>
+            op{std::move(init.completion_handler),
+               *this,
+               this->m_core,
+               std::size_t(0),
+               Botan::TLS::convertException()};
+            boost::asio::async_write(m_nextLayer, this->m_core.sendBuffer(), std::move(op));
             return init.result.get();
             }
 

--- a/src/lib/tls/asio/asio_stream_core.h
+++ b/src/lib/tls/asio/asio_stream_core.h
@@ -106,6 +106,11 @@ struct StreamCore : public Botan::TLS::Callbacks
          m_send_buffer.dynamicBuffer.consume(bytesConsumed);
          }
 
+      void clearSendBuffer()
+         {
+         consumeSendBuffer(m_send_buffer.dynamicBuffer.size());
+         }
+
    private:
       // Buffer space used to read input intended for the engine.
       std::vector<uint8_t> m_input_buffer_space;

--- a/src/tests/unit_asio_stream.cpp
+++ b/src/tests/unit_asio_stream.cpp
@@ -671,7 +671,7 @@ class Asio_Stream_Tests final : public Test
 
          auto write_handler = [&](const error_code &ec, std::size_t bytes_transferred)
             {
-            result.test_eq("didn't transfer anything", bytes_transferred, 0);
+            result.test_eq("committed some bytes to the core", bytes_transferred, TEST_DATA_SIZE);
             result.confirm("propagates error code", ec == net::error::eof);
             };
 


### PR DESCRIPTION
async_write some called the completion_handler directly, if botan threw an exception. Now, it also creates an async_write_op, but passes an error_code.

This PR also introduced tests to cover the try-catch-branches of asio_stream.